### PR TITLE
Update install script slightly to work on Mac

### DIFF
--- a/bin/atb-export-vm.sh
+++ b/bin/atb-export-vm.sh
@@ -1,4 +1,4 @@
-#! /usr/bin/bash
+#! /usr/bin/env bash
 #
 # Author:   Bert Van Vreckem <bert.vanvreckem@gmail.com>
 #

--- a/bin/atb-get-vars.sh
+++ b/bin/atb-get-vars.sh
@@ -1,4 +1,4 @@
-#! /usr/bin/bash
+#! /usr/bin/env bash
 #
 # Author: Bert Van Vreckem <bert.vanvreckem@gmail.com>
 #

--- a/bin/atb-init-role.sh
+++ b/bin/atb-init-role.sh
@@ -1,4 +1,4 @@
-#! /usr/bin/bash
+#! /usr/bin/env bash
 #
 # Author: Bert Van Vreckem <bert.vanvreckem@gmail.com>
 #

--- a/bin/atb-init.sh
+++ b/bin/atb-init.sh
@@ -1,4 +1,4 @@
-#! /usr/bin/bash
+#! /usr/bin/env bash
 #
 # Author:   Bert Van Vreckem <bert.vanvreckem@gmail.com>
 #

--- a/bin/atb-provision.sh
+++ b/bin/atb-provision.sh
@@ -1,4 +1,4 @@
-#! /usr/bin/bash
+#! /usr/bin/env bash
 #
 # Author:   Bert Van Vreckem <bert.vanvreckem@gmail.com>
 #

--- a/bin/atb-role-deps.sh
+++ b/bin/atb-role-deps.sh
@@ -1,4 +1,4 @@
-#! /usr/bin/bash
+#! /usr/bin/env bash
 #
 # Author: Bert Van Vreckem <bert.vanvreckem@gmail.com>
 #

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#! /usr/bin/bash
+#! /usr/bin/env bash
 #
 # Author: Bert Van Vreckem <bert.vanvreckem@gmail.com>
 #

--- a/install.sh
+++ b/install.sh
@@ -46,7 +46,7 @@ install_script() {
   local script_name="${script_path##*/}"
   local cmd_name="${script_name%.sh}"
 
-  install --compare --verbose \
+  install -C -v \
     "${script_path}" "${install_dir}/${cmd_name}"
 }
 


### PR DESCRIPTION
It seems the `install` command shipped with Mac 10.12 does not have the longer `--compare` and `--verbose` flags, causing the `install.sh` script to fail. The abbreviated versions of the flags should work on any platform that has `install`, I believe.

P.S., I'm attempting to emulate your Vagrant/Ansible setup at my company, to enable testing on various platforms. So I might be asking you more questions. :) Great work, here. I really like the clean, simple setup.